### PR TITLE
Fix edit on GitHub URLs

### DIFF
--- a/src/pages/book-summaries/[id].js
+++ b/src/pages/book-summaries/[id].js
@@ -21,7 +21,7 @@ export default function BookSummary({ id, data }) {
     }),
     [data.cover, data.coverAlt]
   );
-  const editUrl = `${GITHUB_REPO_EDIT_URL}/book-summaries/${id}.md`;
+  const editUrl = `${GITHUB_REPO_EDIT_URL}/content/book-summaries/${id}/en-US.md`;
   const discussUrl = `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `https://lucianohgo.com/book-summaries/${id}`
   )}`;

--- a/src/pages/posts/[id].js
+++ b/src/pages/posts/[id].js
@@ -18,7 +18,7 @@ export default function Post({ id, postData }) {
     }),
     [postData.cover, postData.coverAlt]
   );
-  const editUrl = `${GITHUB_REPO_EDIT_URL}/posts/${id}.md`;
+  const editUrl = `${GITHUB_REPO_EDIT_URL}/content/posts/${id}/en-US.md`;
   const discussUrl = `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `https://lucianohgo.com/posts/${id}`
   )}`;


### PR DESCRIPTION
Hello there :wave: 
This fixes the "Edit on GitHub" link that wasn't working.

This will probably need some more work when you decide to support more locales, but for now it's hardcoded to `en-US` everywhere any way.